### PR TITLE
Remove interface pointers from generated code and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,9 +295,9 @@ func main() {
 		Name: "Test Flag Go",
 		Key:  "test-go",
 		Variations: []ldapi.Variation{
-			{Value: intfPtr([]interface{}{1, 2})},
-			{Value: intfPtr([]interface{}{3, 4})},
-			{Value: intfPtr([]interface{}{5})}}}
+			{Value: []int{1, 2}},
+			{Value: []int{3, 4}},
+			{Value: []int{5}}
 	flag, _, err := client.FeatureFlagsApi.PostFeatureFlag(ctx, "openapi", body, nil)
 	if err != nil {
 		panic(fmt.Errorf("create failed: %s", err))
@@ -309,9 +309,5 @@ func main() {
 			panic(fmt.Errorf("delete failed: %s", err))
 		}
 	}()
-}
-
-func intfPtr(i interface{}) *interface{} {
-	return &i
 }
 ```

--- a/model_destination.go
+++ b/model_destination.go
@@ -19,7 +19,7 @@ type Destination struct {
 	// Destination type (\"google-pubsub\", \"kinesis\", \"mparticle\", or \"segment\")
 	Kind string `json:"kind,omitempty"`
 	// destination-specific configuration.
-	Config *interface{} `json:"config,omitempty"`
+	Config interface{} `json:"config,omitempty"`
 	// Whether the data export destination is on or not.
 	On bool `json:"on,omitempty"`
 	Version int32 `json:"version,omitempty"`

--- a/model_destination_body.go
+++ b/model_destination_body.go
@@ -16,7 +16,7 @@ type DestinationBody struct {
 	// The data export destination type. Available choices are kinesis, google-pubsub, mparticle, or segment.
 	Kind string `json:"kind"`
 	// destination-specific configuration.
-	Config *interface{} `json:"config"`
+	Config interface{} `json:"config"`
 	// Whether the data export destination is on or not.
 	On bool `json:"on,omitempty"`
 }

--- a/model_feature_flag_status.go
+++ b/model_feature_flag_status.go
@@ -14,6 +14,6 @@ type FeatureFlagStatus struct {
 	// | Name     | Description | | --------:| ----------- | | new      | the feature flag was created within the last 7 days, and has not been requested yet | | active   | the feature flag was requested by your servers or clients within the last 7 days | | inactive | the feature flag was created more than 7 days ago, and hasn't been requested by your servers or clients within the past 7 days | | launched | one variation of the feature flag has been rolled out to all your users for at least 7 days | 
 	Name string `json:"name,omitempty"`
 	LastRequested string `json:"lastRequested,omitempty"`
-	Default_ *interface{} `json:"default,omitempty"`
+	Default_ interface{} `json:"default,omitempty"`
 	Links *Links `json:"_links,omitempty"`
 }

--- a/model_feature_flag_status_for_queried_environment.go
+++ b/model_feature_flag_status_for_queried_environment.go
@@ -14,5 +14,5 @@ type FeatureFlagStatusForQueriedEnvironment struct {
 	// | Name     | Description | | --------:| ----------- | | new      | the feature flag was created within the last 7 days, and has not been requested yet | | active   | the feature flag was requested by your servers or clients within the last 7 days | | inactive | the feature flag was created more than 7 days ago, and hasn't been requested by your servers or clients within the past 7 days | | launched | one variation of the feature flag has been rolled out to all your users for at least 7 days | 
 	Name string `json:"name,omitempty"`
 	LastRequested string `json:"lastRequested,omitempty"`
-	Default_ *interface{} `json:"default,omitempty"`
+	Default_ interface{} `json:"default,omitempty"`
 }

--- a/model_integration_subscription.go
+++ b/model_integration_subscription.go
@@ -19,7 +19,7 @@ type IntegrationSubscription struct {
 	// The user-defined name associated with this configuration.
 	Name string `json:"name,omitempty"`
 	// A key-value mapping of configuration fields.
-	Config *interface{} `json:"config,omitempty"`
+	Config interface{} `json:"config,omitempty"`
 	Statements []Statement `json:"statements,omitempty"`
 	// Whether or not the integration is currently active.
 	On bool `json:"on,omitempty"`

--- a/model_integrations.go
+++ b/model_integrations.go
@@ -12,6 +12,6 @@ package ldapi
 
 type Integrations struct {
 	// A mapping of integration types to their respective API endpoints.
-	Links *interface{} `json:"_links,omitempty"`
+	Links interface{} `json:"_links,omitempty"`
 	Items []IntegrationSubscription `json:"items,omitempty"`
 }

--- a/model_patch_operation.go
+++ b/model_patch_operation.go
@@ -13,5 +13,5 @@ package ldapi
 type PatchOperation struct {
 	Op string `json:"op"`
 	Path string `json:"path"`
-	Value *interface{} `json:"value"`
+	Value interface{} `json:"value"`
 }

--- a/model_subscription_body.go
+++ b/model_subscription_body.go
@@ -15,7 +15,7 @@ type SubscriptionBody struct {
 	Name string `json:"name"`
 	Statements []Statement `json:"statements,omitempty"`
 	// Integration-specific configuration fields.
-	Config *interface{} `json:"config"`
+	Config interface{} `json:"config"`
 	// Whether the integration subscription is active or not.
 	On bool `json:"on,omitempty"`
 	// Tags for the integration subscription.

--- a/model_user.go
+++ b/model_user.go
@@ -21,5 +21,5 @@ type User struct {
 	Avatar string `json:"avatar,omitempty"`
 	Name string `json:"name,omitempty"`
 	Anonymous bool `json:"anonymous,omitempty"`
-	Custom *interface{} `json:"custom,omitempty"`
+	Custom interface{} `json:"custom,omitempty"`
 }

--- a/model_variation.go
+++ b/model_variation.go
@@ -14,5 +14,5 @@ type Variation struct {
 	Id string `json:"_id,omitempty"`
 	Name string `json:"name,omitempty"`
 	Description string `json:"description,omitempty"`
-	Value *interface{} `json:"value"`
+	Value interface{} `json:"value"`
 }


### PR DESCRIPTION
This is in line with the PR to swagger to stop generating interface pointers for generated golang code.
Notice how much cleaner the code is.

See: https://github.com/swagger-api/swagger-codegen/pull/10932