### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/launchdarkly/api-client-go/7
+module github.com/launchdarkly/api-client-go/v7
 
 go 1.13
 


### PR DESCRIPTION
Manually fix `v7` and tested. Follow up PR will fix the client generation so the `v` is added.